### PR TITLE
TaskList: Refactor markTask to use Stream for task marking

### DIFF
--- a/src/main/java/taskmax/storage/TaskList.java
+++ b/src/main/java/taskmax/storage/TaskList.java
@@ -63,11 +63,16 @@ public class TaskList {
     public void markTask(int index, boolean isDone) throws TaskmaxException {
         assert index >= 0 && index < tasks.size() : "Index out of bounds when marking task";
         validateIndex(index);
-        if (isDone) {
-            tasks.get(index).markAsDone();
-        } else {
-            tasks.get(index).markAsNotDone();
-        }
+        tasks.stream()
+                .skip(index)
+                .findFirst()
+                .ifPresent(task -> {
+                    if (isDone) {
+                        task.markAsDone();
+                    } else {
+                        task.markAsNotDone();
+                    }
+                });
     }
 
     /**


### PR DESCRIPTION
The markTask method originally used direct index access to mark tasks as done. This method has now been refactored to use Stream for finding and marking the task at the given index.

Let's:
* Replace the direct index access with Stream's skip() and findFirst() methods.
* Ensure that the task is marked as done or not done based on the boolean flag.

This change introduces Streams, but it's less efficient than direct list access. However, it aligns with the requirement to use Streams where applicable without compromising the overall structure of the class.